### PR TITLE
Add quality settings for Quest Pro.

### DIFF
--- a/Assets/Settings/Project Configuration/Quest Pro URP Config.asset
+++ b/Assets/Settings/Project Configuration/Quest Pro URP Config.asset
@@ -82,7 +82,7 @@ MonoBehaviour:
   m_Textures:
     blueNoise64LTex: {fileID: 2800000, guid: e3d24661c1e055f45a7560c033dbb837, type: 3}
     bayerMatrixTex: {fileID: 2800000, guid: f9ee4ed84c1d10c49aabb9b210b0fc44, type: 3}
-  m_PrefilteringModeMainLightShadows: 3
+  m_PrefilteringModeMainLightShadows: 0
   m_PrefilteringModeAdditionalLight: 4
   m_PrefilteringModeAdditionalLightShadows: 0
   m_PrefilterXRKeywords: 0

--- a/Assets/Settings/Project Configuration/Quest Pro URP Config.asset
+++ b/Assets/Settings/Project Configuration/Quest Pro URP Config.asset
@@ -1,0 +1,110 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf2edee5c58d82540a51f03df9d42094, type: 3}
+  m_Name: Quest Pro URP Config
+  m_EditorClassIdentifier: 
+  k_AssetVersion: 11
+  k_AssetPreviousVersion: 11
+  m_RendererType: 1
+  m_RendererData: {fileID: 0}
+  m_RendererDataList:
+  - {fileID: 11400000, guid: 53a413327819a984d8ab1618c9e90a10, type: 2}
+  m_DefaultRendererIndex: 0
+  m_RequireDepthTexture: 0
+  m_RequireOpaqueTexture: 0
+  m_OpaqueDownsampling: 1
+  m_SupportsTerrainHoles: 0
+  m_SupportsHDR: 0
+  m_HDRColorBufferPrecision: 0
+  m_MSAA: 4
+  m_RenderScale: 1
+  m_UpscalingFilter: 0
+  m_FsrOverrideSharpness: 1
+  m_FsrSharpness: 0.5
+  m_EnableLODCrossFade: 0
+  m_LODCrossFadeDitheringType: 1
+  m_ShEvalMode: 0
+  m_MainLightRenderingMode: 1
+  m_MainLightShadowsSupported: 0
+  m_MainLightShadowmapResolution: 4096
+  m_AdditionalLightsRenderingMode: 1
+  m_AdditionalLightsPerObjectLimit: 4
+  m_AdditionalLightShadowsSupported: 0
+  m_AdditionalLightsShadowmapResolution: 2048
+  m_AdditionalLightsShadowResolutionTierLow: 256
+  m_AdditionalLightsShadowResolutionTierMedium: 512
+  m_AdditionalLightsShadowResolutionTierHigh: 1024
+  m_ReflectionProbeBlending: 0
+  m_ReflectionProbeBoxProjection: 0
+  m_ShadowDistance: 2.5
+  m_ShadowCascadeCount: 1
+  m_Cascade2Split: 0.095
+  m_Cascade3Split: {x: 0.1, y: 0.3}
+  m_Cascade4Split: {x: 0.067, y: 0.2, z: 0.467}
+  m_CascadeBorder: 0.38
+  m_ShadowDepthBias: 1
+  m_ShadowNormalBias: 0
+  m_AnyShadowsSupported: 1
+  m_SoftShadowsSupported: 0
+  m_ConservativeEnclosingSphere: 1
+  m_NumIterationsEnclosingSphere: 64
+  m_SoftShadowQuality: 2
+  m_AdditionalLightsCookieResolution: 512
+  m_AdditionalLightsCookieFormat: 3
+  m_UseSRPBatcher: 1
+  m_SupportsDynamicBatching: 0
+  m_MixedLightingSupported: 1
+  m_SupportsLightCookies: 1
+  m_SupportsLightLayers: 0
+  m_DebugLevel: 0
+  m_StoreActionsOptimization: 0
+  m_EnableRenderGraph: 0
+  m_UseAdaptivePerformance: 1
+  m_ColorGradingMode: 0
+  m_ColorGradingLutSize: 32
+  m_UseFastSRGBLinearConversion: 0
+  m_SupportDataDrivenLensFlare: 1
+  m_ShadowType: 1
+  m_LocalShadowsSupported: 0
+  m_LocalShadowsAtlasResolution: 256
+  m_MaxPixelLights: 0
+  m_ShadowAtlasResolution: 256
+  m_VolumeFrameworkUpdateMode: 0
+  m_Textures:
+    blueNoise64LTex: {fileID: 2800000, guid: e3d24661c1e055f45a7560c033dbb837, type: 3}
+    bayerMatrixTex: {fileID: 2800000, guid: f9ee4ed84c1d10c49aabb9b210b0fc44, type: 3}
+  m_PrefilteringModeMainLightShadows: 3
+  m_PrefilteringModeAdditionalLight: 4
+  m_PrefilteringModeAdditionalLightShadows: 0
+  m_PrefilterXRKeywords: 0
+  m_PrefilteringModeForwardPlus: 0
+  m_PrefilteringModeDeferredRendering: 0
+  m_PrefilteringModeScreenSpaceOcclusion: 0
+  m_PrefilterDebugKeywords: 1
+  m_PrefilterWriteRenderingLayers: 1
+  m_PrefilterHDROutput: 1
+  m_PrefilterSSAODepthNormals: 1
+  m_PrefilterSSAOSourceDepthLow: 1
+  m_PrefilterSSAOSourceDepthMedium: 1
+  m_PrefilterSSAOSourceDepthHigh: 1
+  m_PrefilterSSAOInterleaved: 1
+  m_PrefilterSSAOBlueNoise: 1
+  m_PrefilterSSAOSampleCountLow: 1
+  m_PrefilterSSAOSampleCountMedium: 1
+  m_PrefilterSSAOSampleCountHigh: 1
+  m_PrefilterDBufferMRT1: 1
+  m_PrefilterDBufferMRT2: 1
+  m_PrefilterDBufferMRT3: 1
+  m_PrefilterScreenCoord: 1
+  m_PrefilterNativeRenderPass: 1
+  m_ShaderVariantLogLevel: 0
+  m_ShadowCascades: 0

--- a/Assets/Settings/Project Configuration/Quest Pro URP Config.asset.meta
+++ b/Assets/Settings/Project Configuration/Quest Pro URP Config.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7a2f76ca4b412380592875eb1cea870a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -4,7 +4,7 @@
 QualitySettings:
   m_ObjectHideFlags: 0
   serializedVersion: 5
-  m_CurrentQuality: 1
+  m_CurrentQuality: 6
   m_QualitySettings:
   - serializedVersion: 3
     name: Very Low
@@ -300,9 +300,58 @@ QualitySettings:
     terrainFadeLength: 5
     terrainMaxTrees: 50
     excludedTargetPlatforms: []
+  - serializedVersion: 3
+    name: Quest Pro
+    pixelLightCount: 4
+    shadows: 2
+    shadowResolution: 2
+    shadowProjection: 1
+    shadowCascades: 4
+    shadowDistance: 150
+    shadowNearPlaneOffset: 3
+    shadowCascade2Split: 0.33333334
+    shadowCascade4Split: {x: 0.06666667, y: 0.2, z: 0.46666667}
+    shadowmaskMode: 1
+    skinWeights: 4
+    globalTextureMipmapLimit: 0
+    textureMipmapLimitSettings: []
+    anisotropicTextures: 2
+    antiAliasing: 4
+    softParticles: 1
+    softVegetation: 1
+    realtimeReflectionProbes: 1
+    billboardsFaceCameraPosition: 1
+    useLegacyDetailDistribution: 1
+    vSyncCount: 0
+    realtimeGICPUUsage: 25
+    lodBias: 2
+    maximumLODLevel: 0
+    enableLODCrossFade: 0
+    streamingMipmapsActive: 0
+    streamingMipmapsAddAllCameras: 1
+    streamingMipmapsMemoryBudget: 512
+    streamingMipmapsRenderersPerFrame: 512
+    streamingMipmapsMaxLevelReduction: 2
+    streamingMipmapsMaxFileIORequests: 1024
+    particleRaycastBudget: 64
+    asyncUploadTimeSlice: 2
+    asyncUploadBufferSize: 16
+    asyncUploadPersistentBuffer: 1
+    resolutionScalingFixedDPIFactor: 1
+    customRenderPipeline: {fileID: 11400000, guid: 7a2f76ca4b412380592875eb1cea870a, type: 2}
+    terrainQualityOverrides: 0
+    terrainPixelError: 1
+    terrainDetailDensityScale: 1
+    terrainBasemapDistance: 1000
+    terrainDetailDistance: 80
+    terrainTreeDistance: 5000
+    terrainBillboardStart: 50
+    terrainFadeLength: 5
+    terrainMaxTrees: 50
+    excludedTargetPlatforms: []
   m_TextureMipmapLimitGroupNames: []
   m_PerPlatformDefaultQuality:
-    Android: 1
+    Android: 6
     Lumin: 5
     Nintendo 3DS: 5
     Nintendo Switch: 5


### PR DESCRIPTION
This changeset adds a new quality level for Quest Pro.
Some adjustments were done relative to the previous settings, more notably texture resolution, anisotropic filtering, and MSAA (not seen in screenshots).

Before:
![quality_before](https://github.com/eundersander/siro_hitl_unity_client/assets/110583667/7b328138-3e72-44be-9360-c688cb2d221d)

After:
![quality_after](https://github.com/eundersander/siro_hitl_unity_client/assets/110583667/1b6ea6fe-459d-418a-82ec-ebd1c503d7a8)
