### PR TITLE
Temporary workaround for gfx-replay scaling.

### DIFF
--- a/Assets/Scripts/GfxReplayPlayer.cs
+++ b/Assets/Scripts/GfxReplayPlayer.cs
@@ -97,10 +97,13 @@ public class GfxReplayPlayer : MonoBehaviour
 
                 GameObject instance = Instantiate(prefab);
 
+                // HACK: Gfx-replay scale is currently invalid. We're ignoring it until the issue is resolved.
+                /*
                 if (creationItem.creation.scale != null)
                 {
                     instance.transform.localScale = new Vector3(creationItem.creation.scale[0], creationItem.creation.scale[1], creationItem.creation.scale[2]);
                 }
+                */
 
                 instance = HandleFrame(instance, load.frame);
 


### PR DESCRIPTION
Temporary workaround for gfx-replay scaling, which is currently incorrect.

Before:
![scale_before](https://github.com/eundersander/siro_hitl_unity_client/assets/110583667/49f4cc5c-b8b3-4a8b-bf4a-07645376416d)

After:
![scale_after](https://github.com/eundersander/siro_hitl_unity_client/assets/110583667/cbbb114c-7b94-4c3f-8a9c-1378621172ca)

