### PR TITLE
Fix memory leak when changing scene.

### DIFF
--- a/Assets/Scripts/GfxReplayPlayer.cs
+++ b/Assets/Scripts/GfxReplayPlayer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -14,7 +15,7 @@ public class GfxReplayPlayer : MonoBehaviour
     static string SimplifyRelativePath(string path)
     {
         string[] parts = path.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
-        var simplifiedParts = new System.Collections.Generic.List<string>();
+        var simplifiedParts = new List<string>();
 
         foreach (var part in parts)
         {
@@ -119,7 +120,6 @@ public class GfxReplayPlayer : MonoBehaviour
                     Vector3 translation = CoordinateConventionHelper.ToUnityVector(update.state.absTransform.translation);
                     Quaternion rotation = CoordinateConventionHelper.ToUnityQuaternion(update.state.absTransform.rotation);
 
-
                     instance.transform.position = translation;
                     instance.transform.rotation = rotation;
                 }
@@ -136,8 +136,7 @@ public class GfxReplayPlayer : MonoBehaviour
                     _instanceDictionary.Remove(key);
                 }
             }
-            Resources.UnloadUnusedAssets();
-            GC.Collect();
+            StartCoroutine("ReleaseUnusedMemory");
             Debug.Log($"Processed {keyframe.deletions.Length} deletions!");
         }
     }
@@ -148,9 +147,17 @@ public class GfxReplayPlayer : MonoBehaviour
         {
             Destroy(kvp.Value);
         }
-        Resources.UnloadUnusedAssets();
-        GC.Collect();
+        StartCoroutine("ReleaseUnusedMemory");
         Debug.Log($"Deleted all {_instanceDictionary.Count} instances!");
         _instanceDictionary.Clear();
+    }
+
+    IEnumerator ReleaseUnusedMemory()
+    {
+        // Wait for objects to be destroyed.
+        yield return new WaitForEndOfFrame();
+
+        Resources.UnloadUnusedAssets();
+        GC.Collect();
     }
 }

--- a/Assets/Scripts/GfxReplayPlayer.cs
+++ b/Assets/Scripts/GfxReplayPlayer.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using UnityEngine;
-using UnityEngine.InputSystem;
 
 public class GfxReplayPlayer : MonoBehaviour
 {
@@ -118,33 +116,12 @@ public class GfxReplayPlayer : MonoBehaviour
                 {
                     GameObject instance = _instanceDictionary[update.instanceKey];
 
-                    // Note various negations to adjust handedness and coordinate
-                    // convention.
-                    // Extract translation and rotation from the update state
-                    //Vector3 translation = new Vector3(
-                    //    update.state.absTransform.translation[0],
-                    //    update.state.absTransform.translation[1],
-                    //    -update.state.absTransform.translation[2]
-                    //);
-
                     Vector3 translation = CoordinateConventionHelper.ToUnityVector(update.state.absTransform.translation);
-
-                    //Quaternion rotation = new Quaternion(
-                    //    update.state.absTransform.rotation[1],
-                    //    -update.state.absTransform.rotation[2],
-                    //    -update.state.absTransform.rotation[3],
-                    //    update.state.absTransform.rotation[0]
-                    //);
-                    // rotation = _defaultRotation * rotation;
                     Quaternion rotation = CoordinateConventionHelper.ToUnityQuaternion(update.state.absTransform.rotation);
 
 
                     instance.transform.position = translation;
                     instance.transform.rotation = rotation;
-
-                    // temp hack
-                    //instance.isStatic = true;
-
                 }
             }
         }
@@ -159,6 +136,8 @@ public class GfxReplayPlayer : MonoBehaviour
                     _instanceDictionary.Remove(key);
                 }
             }
+            Resources.UnloadUnusedAssets();
+            GC.Collect();
             Debug.Log($"Processed {keyframe.deletions.Length} deletions!");
         }
     }
@@ -169,6 +148,8 @@ public class GfxReplayPlayer : MonoBehaviour
         {
             Destroy(kvp.Value);
         }
+        Resources.UnloadUnusedAssets();
+        GC.Collect();
         Debug.Log($"Deleted all {_instanceDictionary.Count} instances!");
         _instanceDictionary.Clear();
     }


### PR DESCRIPTION
This changeset forces Unity to clean resources when we change scene.

Typically, Unity does this when unloading a scene. However, we are always using a single scene in which we dynamically load objects.

`Resources.UnloadUnusedAssets()` is used to release memory. Because `Destroy()` is not immediate, i.e. handled at the end of the frame, we wait for the end of the frame before releasing memory.

**Note:** This method of cleaning resource is a bit hacky. Scene changes are also slower. Unity now recommends to use [Addressables](https://docs.unity3d.com/Manual/com.unity.addressables.html) instead of `Resources`. These allow for precise control of when assets are loaded and unloaded.

**Before:**
https://github.com/eundersander/siro_hitl_unity_client/assets/110583667/dd82ba7a-170f-40bf-95d1-e1d80f34ab4c

**After:**
https://github.com/eundersander/siro_hitl_unity_client/assets/110583667/7a18c863-c149-478f-9f6a-d07c29c30c21

