### PR TITLE
Improve HSSD materials interpretation in Unity

### DIFF
--- a/Packages/com.siccity.gltfutility@96619fcd48/Scripts/Importer.cs
+++ b/Packages/com.siccity.gltfutility@96619fcd48/Scripts/Importer.cs
@@ -370,7 +370,7 @@ namespace Siccity.GLTFUtility {
 						case "KHR_draco_mesh_compression":
 							break;
 						default:
-							Debug.LogWarning($"GLTFUtility: Required extension '{gLTFObject.extensionsRequired[i]}' not supported. Import process will proceed but results may vary.");
+							Debug.LogWarning($"GLTFUtility: Required extension '{gLTFObject.extensionsRequired[i]}' not supported. Import process will proceed but results may vary.\nAffected asset: '{gLTFObject.scenes[0].name}'.");
 							break;
 					}
 				}

--- a/Packages/com.siccity.gltfutility@96619fcd48/Scripts/Spec/GLTFMaterial.cs
+++ b/Packages/com.siccity.gltfutility@96619fcd48/Scripts/Spec/GLTFMaterial.cs
@@ -120,6 +120,11 @@ namespace Siccity.GLTFUtility {
 				mat.SetFloat("_Roughness", correctedRoughnessFactor);
 			}
 
+			// HACK: Force removal of roughness for glass materials
+			if (name == "FP_GLASS" || name == "MIRROR") {
+				mat.SetFloat("_Roughness", 0.0f);
+			}
+
 			mat.name = name;
 			onFinish(mat);
 		}


### PR DESCRIPTION
This change adds `KHR_materials_ior` and `KHR_materials_specular` to the GLTF importer.

While these values are not used by URP shaders, an heuristic is added to modulate roughness based on these values. This attenuates excessively glossy materials.

| Before | After |
| -------- | ------- |
| ![material_fix_before](https://github.com/eundersander/siro_hitl_unity_client/assets/110583667/ef1b60fb-3884-45ce-80fe-3849de0fc4fa) | ![material_fix_after](https://github.com/eundersander/siro_hitl_unity_client/assets/110583667/8bb9bef9-1aa0-4fc4-af5e-982e41fde1ff) |

Furthermore, this adds a hack to force glass materials (mirrors and glass) to have no roughness. These materials are shared across HSSD.

