### PR TITLE
multi-server support

### DIFF
--- a/Assets/Scenes/GfxReplayPlayerScene.unity
+++ b/Assets/Scenes/GfxReplayPlayerScene.unity
@@ -420,6 +420,7 @@ GameObject:
   - component: {fileID: 695650933}
   - component: {fileID: 695650935}
   - component: {fileID: 695650936}
+  - component: {fileID: 695650937}
   m_Layer: 0
   m_Name: ScriptSingletonsObject
   m_TagString: Untagged
@@ -454,8 +455,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cb1d99323d59a4e70a3d43daba019d51, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  serverAddress: 127.0.0.1
-  serverPort: 8888
+  defaultServerPort: 8888
   vrHeadsetObject: {fileID: 1708247983}
   vrLeftControllerObject: {fileID: 2075813056}
   vrRightControllerObject: {fileID: 1032753413}
@@ -496,6 +496,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d3f4aee02592748d69ef975f49a36ffc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &695650937
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 695650929}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 887d79a418cbc4c15bacfe9983a11b44, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _mouseoverForTooltip: 0
+  defaultServerLocations:
+  - 192.168.4.26
+  - 192.168.4.58:8888
 --- !u!1001 &878938825
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ConfigLoader.cs
+++ b/Assets/Scripts/ConfigLoader.cs
@@ -1,0 +1,67 @@
+using UnityEngine;
+using System.IO;
+using UnityEngine.Assertions;
+
+public class ConfigLoader : MonoBehaviour
+{
+    [System.Serializable]
+    public class Config
+    {
+        public string[] serverLocations;
+        // public int visualQuality;
+    }
+
+    [Header("Config Defaults")]
+    [Tooltip("Config defaults are used directly when runing in the Editor. On device, they are used to populate config.txt at Android/data/com.meta.siro_hitl_vr_client/files/. This file persists and can be edited between runs, e.g. by connecting via USB to a laptop.")]
+    [SerializeField]
+    private bool _mouseoverForTooltip;  // dummy member so we can add tooltip in Inspector pane
+    [Space(10)] // Add a little spacing for clarity
+
+    [SerializeField] private string[] defaultServerLocations = { "1.2.3.4", "1.2.3.5:6789" };
+    // [SerializeField] private int defaultVisualQuality = 2;
+
+    private Config _config;
+
+    public Config AppConfig
+    {
+        get
+        {
+            if (_config == null)
+            {
+                LoadOrCreateConfig();
+            }
+            return _config;
+        }
+    }
+
+    private void LoadOrCreateConfig()
+    {
+#if UNITY_EDITOR
+        _config = CreateDefaultConfig();
+        return;
+#else
+
+        string configPath = Path.Combine(Application.persistentDataPath, "config.txt");
+        if (File.Exists(configPath))
+        {
+            string json = File.ReadAllText(configPath);
+            _config = JsonUtility.FromJson<Config>(json);
+        }
+        else
+        {
+            _config = CreateDefaultConfig();
+            string json = JsonUtility.ToJson(_config);
+            File.WriteAllText(configPath, json);
+        }
+#endif
+    }
+
+    private Config CreateDefaultConfig()
+    {
+        return new Config
+        {
+            serverLocations = defaultServerLocations,
+            // visualQuality = defaultVisualQuality
+        };
+    }
+}

--- a/Assets/Scripts/ConfigLoader.cs.meta
+++ b/Assets/Scripts/ConfigLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 887d79a418cbc4c15bacfe9983a11b44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is logic to continually try a list of servers, sequentially. I have to awkwardly force a timeout on the websocket connection because there isn't a timeout API and the built-in timeout seems to be ~60s. All this async logic is complicated and messy so please take a close look for bugs!

This also adds `ConfigLoader`. The only config item so far is the list of servers. When running in the Editor, the config is populated directly from the "config defaults" specified in the component (inspector pane). When running on device, the config defaults are used to populate config.txt, which then persists across runs and can be edited between runs, e.g. via USB connection to an Android phone or Linux laptop (still couldn't figure out Mac!).