### PR TITLE
Add effect to indicate that the episode has changed.

### DIFF
--- a/Assets/Scenes/GfxReplayPlayerScene.unity
+++ b/Assets/Scenes/GfxReplayPlayerScene.unity
@@ -14,10 +14,10 @@ OcclusionCullingSettings:
 RenderSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 9
-  m_Fog: 0
-  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_Fog: 1
+  m_FogColor: {r: 0, g: 0, b: 0, a: 1}
   m_FogMode: 3
-  m_FogDensity: 0.01
+  m_FogDensity: 0
   m_LinearFogStart: 0
   m_LinearFogEnd: 300
   m_AmbientSkyColor: {r: 0.26415092, g: 0.26415092, b: 0.26415092, a: 1}

--- a/Assets/Scripts/GfxReplayPlayer.cs
+++ b/Assets/Scripts/GfxReplayPlayer.cs
@@ -23,6 +23,7 @@ public class GfxReplayPlayer : MonoBehaviour
 
     HighlightManager _highlightManager;
     AvatarPositionHandler _avatarPositionHandler;
+    StatusDisplayHelper _statusDisplayHelper;
 
     private Dictionary<int, MovementData> _movementData = new Dictionary<int, MovementData>();
     private float _keyframeInterval = 0.1f;  // assume 10Hz, but see also SetKeyframeRate
@@ -39,6 +40,11 @@ public class GfxReplayPlayer : MonoBehaviour
         if (_avatarPositionHandler == null)
         {
             Debug.LogWarning($"Avatar position handler missing from '{name}'. Avatar position updates will be ignored.");
+        }
+        _statusDisplayHelper = GetComponent<StatusDisplayHelper>();
+        if (_statusDisplayHelper == null)
+        {
+            Debug.LogWarning($"Status display helper missing from '{name}'. Status updates will be ignored.");
         }
     }
 
@@ -234,6 +240,12 @@ public class GfxReplayPlayer : MonoBehaviour
 
     public void ProcessKeyframe(KeyframeData keyframe)
     {
+        // If the episode is changing, show an indicator.
+        if (_statusDisplayHelper != null && keyframe.message != null && keyframe.message.episodeChanged)
+        {
+            _statusDisplayHelper.OnEpisodeChanged();
+        }
+
         // Handle Loads
         if (keyframe.loads != null)
         {

--- a/Assets/Scripts/GfxReplayPlayer.cs
+++ b/Assets/Scripts/GfxReplayPlayer.cs
@@ -241,9 +241,9 @@ public class GfxReplayPlayer : MonoBehaviour
     public void ProcessKeyframe(KeyframeData keyframe)
     {
         // If the episode is changing, show an indicator.
-        if (_statusDisplayHelper != null && keyframe.message != null && keyframe.message.episodeChanged)
+        if (_statusDisplayHelper != null && keyframe.message != null && keyframe.message.sceneChanged)
         {
-            _statusDisplayHelper.OnEpisodeChanged();
+            _statusDisplayHelper.OnSceneChanged();
         }
 
         // Handle Loads

--- a/Assets/Scripts/GfxReplayPlayer.cs
+++ b/Assets/Scripts/GfxReplayPlayer.cs
@@ -19,7 +19,6 @@ public class GfxReplayPlayer : MonoBehaviour
 
     private Dictionary<int, GameObject> _instanceDictionary = new Dictionary<int, GameObject>();
     private Dictionary<string, Load> _loadDictionary = new Dictionary<string, Load>();
-    private Quaternion _defaultRotation = Quaternion.Euler(0, 180, 0);
 
     HighlightManager _highlightManager;
     AvatarPositionHandler _avatarPositionHandler;
@@ -240,10 +239,18 @@ public class GfxReplayPlayer : MonoBehaviour
 
     public void ProcessKeyframe(KeyframeData keyframe)
     {
-        // If the episode is changing, show an indicator.
+        // Handle messages
+        if (_highlightManager)
+        {
+            _highlightManager.ProcessKeyframe(keyframe);
+        }
+        if (_avatarPositionHandler)
+        {
+            _avatarPositionHandler.ProcessKeyframe(keyframe);
+        }
         if (_statusDisplayHelper != null && keyframe.message != null && keyframe.message.sceneChanged)
         {
-            _statusDisplayHelper.OnSceneChanged();
+            _statusDisplayHelper.OnSceneChangeBegin();
         }
 
         // Handle Loads
@@ -292,7 +299,6 @@ public class GfxReplayPlayer : MonoBehaviour
 
         ProcessStateUpdates(keyframe);
 
-
         // Handle Deletions
         if (keyframe.deletions != null)
         {
@@ -304,18 +310,23 @@ public class GfxReplayPlayer : MonoBehaviour
                     _instanceDictionary.Remove(key);
                 }
             }
-            StartCoroutine("ReleaseUnusedMemory");
+            StartCoroutine(ReleaseUnusedMemory(
+                // Wait for memory clean-up to be finished before executing KeyframePostUpdate()
+                () => {KeyframePostUpdate(keyframe);})
+            );
             Debug.Log($"Processed {keyframe.deletions.Length} deletions!");
         }
-
-        // Handle message
-        if (_highlightManager)
+        else
         {
-            _highlightManager.ProcessKeyframe(keyframe);
+            KeyframePostUpdate(keyframe);
         }
-        if (_avatarPositionHandler)
+    }
+
+    void KeyframePostUpdate(KeyframeData keyframe)
+    {
+        if (_statusDisplayHelper != null && keyframe.message != null && keyframe.message.sceneChanged)
         {
-            _avatarPositionHandler.ProcessKeyframe(keyframe);
+            _statusDisplayHelper.OnSceneChangeEnd();
         }
     }
 
@@ -325,17 +336,37 @@ public class GfxReplayPlayer : MonoBehaviour
         {
             Destroy(kvp.Value);
         }
-        StartCoroutine("ReleaseUnusedMemory");
+        StartCoroutine(ReleaseUnusedMemory());
         Debug.Log($"Deleted all {_instanceDictionary.Count} instances!");
         _instanceDictionary.Clear();
     }
 
-    IEnumerator ReleaseUnusedMemory()
+    /// <summary>
+    /// Unloads the unused resources from GPU and CPU memory.
+    /// This is normally done automatically when changing scene.
+    /// We must call this manually to avoid leaks because we are never changing scene.
+    /// This is a slow operation - use the callback to execute code after this is done.
+    /// </summary>
+    /// <param name="callback">Code to execute when this is done.</param>
+    /// <returns></returns>
+    IEnumerator ReleaseUnusedMemory(Action callback = null)
     {
         // Wait for objects to be destroyed.
         yield return new WaitForEndOfFrame();
 
-        Resources.UnloadUnusedAssets();
-        GC.Collect();
+        // Unload unused assets.
+        var asyncOp = Resources.UnloadUnusedAssets();
+
+        // Wait for the operation to be done.
+        while (!asyncOp.isDone)
+        {
+            yield return null;
+        }
+
+        // Invoke callback.
+        if (callback != null)
+        {
+            callback.Invoke();
+        }
     }
 }

--- a/Assets/Scripts/Keyframe.cs
+++ b/Assets/Scripts/Keyframe.cs
@@ -82,6 +82,8 @@ public class Message
     public Highlight[] highlights;
 
     public List<float> teleportAvatarBasePosition;
+
+    public bool episodeChanged;
 }
 
 [Serializable]

--- a/Assets/Scripts/Keyframe.cs
+++ b/Assets/Scripts/Keyframe.cs
@@ -83,7 +83,7 @@ public class Message
 
     public List<float> teleportAvatarBasePosition;
 
-    public bool episodeChanged;
+    public bool sceneChanged;
 }
 
 [Serializable]

--- a/Assets/Scripts/StatusDisplayHelper.cs
+++ b/Assets/Scripts/StatusDisplayHelper.cs
@@ -87,7 +87,7 @@ public class StatusDisplayHelper : MonoBehaviour
         RenderSettings.ambientLight = _ambientColor;
     }
 
-    public void OnEpisodeChanged()
+    public void OnSceneChanged()
     {
         RenderSettings.fog = true;
         RenderSettings.fogDensity = 1.0f;

--- a/Assets/Scripts/StatusDisplayHelper.cs
+++ b/Assets/Scripts/StatusDisplayHelper.cs
@@ -24,6 +24,10 @@ public class StatusDisplayHelper : MonoBehaviour
 
     Transform _iconTargetTransform;
 
+
+    Coroutine _networkStatusIconCoroutine = null;
+    Coroutine _sceneChangeCoroutine = null;
+
     void Awake()
     {
         offlineIcon.SetActive(false);
@@ -75,7 +79,12 @@ public class StatusDisplayHelper : MonoBehaviour
 
     void OnConnectionLost()
     {
-        StartCoroutine(ShowElementForDuration(offlineIcon, offlineIconDisplayTime));
+        if (_networkStatusIconCoroutine != null)
+        {
+            StopCoroutine(_networkStatusIconCoroutine);
+        }
+        _networkStatusIconCoroutine = StartCoroutine(ShowElementForDuration(offlineIcon, offlineIconDisplayTime));
+        
         RenderSettings.ambientLight = Color.red;
         offlineIcon.transform.position = _iconTargetTransform.position;
         offlineIcon.transform.rotation = _iconTargetTransform.rotation;
@@ -87,11 +96,20 @@ public class StatusDisplayHelper : MonoBehaviour
         RenderSettings.ambientLight = _ambientColor;
     }
 
-    public void OnSceneChanged()
+    public void OnSceneChangeBegin()
     {
         RenderSettings.fog = true;
         RenderSettings.fogDensity = 1.0f;
-        StartCoroutine(LerpRemoveFog(0.75f));
+
+        if (_sceneChangeCoroutine != null)
+        {
+            StopCoroutine(_sceneChangeCoroutine);
+        }
+    }
+
+    public void OnSceneChangeEnd()
+    {
+        _sceneChangeCoroutine = StartCoroutine(LerpRemoveFog(0.75f));
     }
 
     IEnumerator ShowElementForDuration(GameObject o, float time)

--- a/Assets/Scripts/StatusDisplayHelper.cs
+++ b/Assets/Scripts/StatusDisplayHelper.cs
@@ -34,6 +34,12 @@ public class StatusDisplayHelper : MonoBehaviour
         }
         _ambientColor = RenderSettings.ambientLight;
         _iconTargetTransform = new GameObject("Icon target transform").transform;
+
+        // Initialize fog
+        RenderSettings.fogMode = FogMode.ExponentialSquared;
+        RenderSettings.fogColor = Color.black;
+        RenderSettings.fog = false;
+        RenderSettings.fogDensity = 0.0f;
     }
 
     void Update()
@@ -81,10 +87,34 @@ public class StatusDisplayHelper : MonoBehaviour
         RenderSettings.ambientLight = _ambientColor;
     }
 
+    public void OnEpisodeChanged()
+    {
+        RenderSettings.fog = true;
+        RenderSettings.fogDensity = 1.0f;
+        StartCoroutine(LerpRemoveFog(0.75f));
+    }
+
     IEnumerator ShowElementForDuration(GameObject o, float time)
     {
         o.SetActive(true);
         yield return new WaitForSeconds(time);
         o.SetActive(false);
+    }
+
+    IEnumerator LerpRemoveFog(float duration)
+    {
+        float initialFogDensity = RenderSettings.fogDensity;
+        float elapsedTime = 0.0f;
+
+        while (elapsedTime < duration)
+        {
+            float fogDensity = Mathf.Lerp(initialFogDensity, 0.0f, elapsedTime / duration);
+            RenderSettings.fogDensity = fogDensity;
+
+            elapsedTime += Time.deltaTime;
+            yield return null; // Skip one frame
+        }
+
+        RenderSettings.fog = false;
     }
 }


### PR DESCRIPTION
This adds a receding fog effect when the episode changes.

Caveat: Because we load entire keyframes at once, the image freezes when the scene is being changed. The fix would be to load keyframes asynchronously in coroutines. This will be polished if time permits.

Video:
https://github.com/eundersander/siro_hitl_unity_client/assets/110583667/88d1d8ad-c997-45d6-bf95-130ccbe9b9b0

Depends on:
https://github.com/facebookresearch/habitat-lab/pull/1674
