### PR TITLE
Add navmesh to restrict teleportation

### DIFF
--- a/Assets/Scenes/GfxReplayPlayerScene.unity
+++ b/Assets/Scenes/GfxReplayPlayerScene.unity
@@ -241,172 +241,6 @@ Light:
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
---- !u!1 &299427828
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 299427831}
-  - component: {fileID: 299427830}
-  - component: {fileID: 299427829}
-  m_Layer: 0
-  m_Name: Floor
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &299427829
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 299427828}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 38f6bf3d943ac7945842268c9ef1dca6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_InteractionManager: {fileID: 0}
-  m_Colliders:
-  - {fileID: 299427830}
-  m_InteractionLayerMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_InteractionLayers:
-    m_Bits: 2147483648
-  m_DistanceCalculationMode: 1
-  m_SelectMode: 1
-  m_FocusMode: 1
-  m_CustomReticle: {fileID: 0}
-  m_AllowGazeInteraction: 0
-  m_AllowGazeSelect: 0
-  m_OverrideGazeTimeToSelect: 0
-  m_GazeTimeToSelect: 0.5
-  m_OverrideTimeToAutoDeselectGaze: 0
-  m_TimeToAutoDeselectGaze: 3
-  m_AllowGazeAssistance: 0
-  m_FirstHoverEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_LastHoverExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_HoverEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_HoverExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FirstSelectEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_LastSelectExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_SelectEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_SelectExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FirstFocusEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_LastFocusExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FocusEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FocusExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Activated:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Deactivated:
-    m_PersistentCalls:
-      m_Calls: []
-  m_StartingHoverFilters: []
-  m_StartingSelectFilters: []
-  m_StartingInteractionStrengthFilters: []
-  m_OnFirstHoverEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnLastHoverExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnHoverEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnHoverExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnSelectEntered:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnSelectExited:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnSelectCanceled:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnActivate:
-    m_PersistentCalls:
-      m_Calls: []
-  m_OnDeactivate:
-    m_PersistentCalls:
-      m_Calls: []
-  m_TeleportationProvider: {fileID: 0}
-  m_MatchOrientation: 0
-  m_MatchDirectionalInput: 1
-  m_TeleportTrigger: 0
-  m_FilterSelectionByHitNormal: 0
-  m_UpNormalToleranceDegrees: 30
-  m_Teleporting:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!65 &299427830
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 299427828}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 100, y: 1, z: 100}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!4 &299427831
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 299427828}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.5, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &579385221
 GameObject:
   m_ObjectHideFlags: 0
@@ -513,6 +347,111 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 579385221}
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &689594125
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 689594129}
+  - component: {fileID: 689594128}
+  - component: {fileID: 689594127}
+  - component: {fileID: 689594126}
+  m_Layer: 2
+  m_Name: CollisionFloor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &689594126
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689594125}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &689594127
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689594125}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &689594128
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689594125}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &689594129
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689594125}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.5, z: 0}
+  m_LocalScale: {x: 500, y: 1, z: 500}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &695650929
 GameObject:
   m_ObjectHideFlags: 0
@@ -670,6 +609,186 @@ MonoBehaviour:
   offlineIcon: {fileID: 1473937394}
   offlineIconDisplayTime: 5
   uiPlaneDistance: 3
+--- !u!1 &763016502
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 763016508}
+  - component: {fileID: 763016505}
+  - component: {fileID: 763016504}
+  - component: {fileID: 763016503}
+  m_Layer: 0
+  m_Name: Navmesh
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &763016503
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763016502}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 63d9fe3cbcf2741648f7a194ce451925, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &763016504
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763016502}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 38f6bf3d943ac7945842268c9ef1dca6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_InteractionManager: {fileID: 0}
+  m_Colliders:
+  - {fileID: 763016505}
+  m_InteractionLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_InteractionLayers:
+    m_Bits: 2147483648
+  m_DistanceCalculationMode: 1
+  m_SelectMode: 1
+  m_FocusMode: 1
+  m_CustomReticle: {fileID: 0}
+  m_AllowGazeInteraction: 0
+  m_AllowGazeSelect: 0
+  m_OverrideGazeTimeToSelect: 0
+  m_GazeTimeToSelect: 0.5
+  m_OverrideTimeToAutoDeselectGaze: 0
+  m_TimeToAutoDeselectGaze: 3
+  m_AllowGazeAssistance: 0
+  m_FirstHoverEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastHoverExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_HoverEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_HoverExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstSelectEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastSelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_SelectEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_SelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FirstFocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_LastFocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FocusExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Activated:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Deactivated:
+    m_PersistentCalls:
+      m_Calls: []
+  m_StartingHoverFilters: []
+  m_StartingSelectFilters: []
+  m_StartingInteractionStrengthFilters: []
+  m_OnFirstHoverEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnLastHoverExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnHoverEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnHoverExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSelectEntered:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSelectExited:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSelectCanceled:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnActivate:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnDeactivate:
+    m_PersistentCalls:
+      m_Calls: []
+  m_TeleportationProvider: {fileID: 0}
+  m_MatchOrientation: 0
+  m_MatchDirectionalInput: 1
+  m_TeleportTrigger: 0
+  m_FilterSelectionByHitNormal: 0
+  m_UpNormalToleranceDegrees: 30
+  m_Teleporting:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!64 &763016505
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763016502}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 0}
+--- !u!4 &763016508
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763016502}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &878938825
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1199,7 +1318,8 @@ SceneRoots:
   m_Roots:
   - {fileID: 695650931}
   - {fileID: 965130855}
-  - {fileID: 299427831}
   - {fileID: 878938825}
   - {fileID: 975252272}
   - {fileID: 1192863549}
+  - {fileID: 763016508}
+  - {fileID: 689594129}

--- a/Assets/Scripts/GfxReplayPlayer.cs
+++ b/Assets/Scripts/GfxReplayPlayer.cs
@@ -23,6 +23,7 @@ public class GfxReplayPlayer : MonoBehaviour
 
     HighlightManager _highlightManager;
     AvatarPositionHandler _avatarPositionHandler;
+    NavmeshHelper _navmeshHelper;
 
     private Dictionary<int, MovementData> _movementData = new Dictionary<int, MovementData>();
     private float _keyframeInterval = 0.1f;  // assume 10Hz, but see also SetKeyframeRate
@@ -39,6 +40,12 @@ public class GfxReplayPlayer : MonoBehaviour
         if (_avatarPositionHandler == null)
         {
             Debug.LogWarning($"Avatar position handler missing from '{name}'. Avatar position updates will be ignored.");
+        }
+
+        _navmeshHelper = GameObject.FindObjectOfType<NavmeshHelper>();
+        if (!_navmeshHelper)
+        {
+            Debug.LogWarning($"Couldn't find a NavmeshHelper. Navmesh updates will be ignored.");
         }
     }
 
@@ -232,8 +239,39 @@ public class GfxReplayPlayer : MonoBehaviour
         }
     }
 
+    private void ProcessKeyframeMessage(Message message)
+    {
+        if (_navmeshHelper != null && message.navmeshVertices != null && message.navmeshVertices.Count > 0)
+        {
+            if (message.navmeshVertices.Count % 9 != 0)
+            {
+                Debug.LogError($"Ignoring keyframe.message.navmeshVertices with Count == {message.navmeshVertices.Count}. Length should be a multiple of 9.");
+            }
+            else
+            {
+                // convert to Vector3[]
+                Vector3[] vectorArray = new Vector3[message.navmeshVertices.Count / 3];
+                for (int i = 0; i < message.navmeshVertices.Count; i += 3)
+                {
+                    vectorArray[i / 3] = CoordinateConventionHelper.ToUnityVector(message.navmeshVertices[i], message.navmeshVertices[i + 1], message.navmeshVertices[i + 2]);
+                }
+
+                // it's too error-prone to expect the server to know the
+                // correct winding order for Unity raycasts, so let's do
+                // double-sided.
+                bool doDoublesided = true;
+                _navmeshHelper.UpdateNavmesh(vectorArray, doDoublesided);
+            }
+        }
+    }
+
     public void ProcessKeyframe(KeyframeData keyframe)
     {
+        if (keyframe.message != null)
+        {
+            ProcessKeyframeMessage(keyframe.message);
+        }
+
         // Handle Loads
         if (keyframe.loads != null)
         {

--- a/Assets/Scripts/Keyframe.cs
+++ b/Assets/Scripts/Keyframe.cs
@@ -82,6 +82,9 @@ public class Message
     public Highlight[] highlights;
 
     public List<float> teleportAvatarBasePosition;
+
+    // nonindexed triangle list, serialized as a flat list of floats
+    public List<float> navmeshVertices;
 }
 
 [Serializable]

--- a/Assets/Scripts/NavmeshHelper.cs
+++ b/Assets/Scripts/NavmeshHelper.cs
@@ -1,0 +1,106 @@
+using UnityEngine;
+using UnityEngine.Assertions;
+using UnityEngine.XR.Interaction.Toolkit;
+
+/// <summary>
+/// This class should be provided a navmesh as triangles (UpdateNavmesh).
+/// It currently uses the navmesh to restrict VR teleportation, but we don't
+/// fully restrict avatar movement. Because of this, user code should still
+/// provide a floor collision plane, to prevent the avatar falling through
+/// the world when it leaves the navmesh.
+/// </summary>
+public class NavmeshHelper : MonoBehaviour
+{
+    private TeleportationArea _teleportationArea;
+    private MeshCollider _meshCollider;
+
+    private static Vector3[] CreateGroundPlane(float size)
+    {
+        // Each three indices represent one triangle
+        Vector3[] vertices = new Vector3[6];
+
+        float halfSize = size / 2;
+
+        // First triangle vertices (bottom left triangle)
+        vertices[0] = new Vector3(-halfSize, 0, -halfSize); // Bottom left corner
+        vertices[1] = new Vector3(halfSize, 0, -halfSize);  // Bottom right corner
+        vertices[2] = new Vector3(-halfSize, 0, halfSize);  // Top left corner
+
+        // Second triangle vertices (top right triangle)
+        vertices[3] = new Vector3(halfSize, 0, -halfSize);  // Bottom right corner
+        vertices[4] = new Vector3(halfSize, 0, halfSize);   // Top right corner
+        vertices[5] = new Vector3(-halfSize, 0, halfSize);  // Top left corner
+
+        return vertices;
+    }
+
+    public void UpdateNavmesh(Vector3[] vertices, bool doDoublesided)
+    {
+        if (vertices == null || vertices.Length % 3 != 0)
+        {
+            Debug.LogError("Vertices array is invalid. It must contain a multiple of three vertices.");
+            return;
+        }
+
+        // Create a new mesh
+        Mesh mesh = new Mesh();
+        mesh.name = "navmesh";
+
+        // Set the vertices
+        mesh.vertices = vertices;
+
+        // Define triangles based on the vertices
+        int[] triangles;
+        if (doDoublesided)
+        {
+            // Double the triangle array size for the two-sided mesh
+            triangles = new int[vertices.Length * 2];
+            for (int i = 0; i < vertices.Length; i += 3)
+            {
+                // Front-facing triangle
+                triangles[i * 2] = i;
+                triangles[i * 2 + 1] = i + 1;
+                triangles[i * 2 + 2] = i + 2;
+                // Back-facing triangle (reversing the order for the winding)
+                triangles[i * 2 + 3] = i;
+                triangles[i * 2 + 4] = i + 2;
+                triangles[i * 2 + 5] = i + 1;
+            }
+        }
+        else
+        {
+            triangles = new int[vertices.Length];
+            for (int i = 0; i < vertices.Length; i++)
+            {
+                triangles[i] = i;
+            }
+        }
+        mesh.triangles = triangles;
+
+        // Calculate normals (required for collision)
+        mesh.RecalculateNormals();
+
+        // Assign the mesh to the Mesh Collider
+        _meshCollider.sharedMesh = mesh;
+    }
+
+
+    void Start()
+    {
+        // todo: instead of requiring these components, this class should
+        // programmatically create them. See
+        // https://app.asana.com/0/1205278804336681/1205931235223778
+        _teleportationArea = GetComponent<TeleportationArea>();
+        Assert.IsTrue(_teleportationArea);  // our object should have a TeleportationArea
+
+        _meshCollider = GetComponent<MeshCollider>();
+        Assert.IsTrue(_meshCollider);
+        Assert.IsTrue(_teleportationArea.colliders.Count == 1);
+
+        // By default, we use a ground plane as the navmesh. This allows
+        // basically unrestricted teleportation.
+        UpdateNavmesh(CreateGroundPlane(200), true);
+    }
+
+}
+

--- a/Assets/Scripts/NavmeshHelper.cs.meta
+++ b/Assets/Scripts/NavmeshHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63d9fe3cbcf2741648f7a194ce451925
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/XRInputHelperComponent.cs
+++ b/Assets/Scripts/XRInputHelperComponent.cs
@@ -117,6 +117,14 @@ public class CoordinateConventionHelper
     private static Quaternion _defaultRotation = Quaternion.Euler(0, 180, 0);
     private static Quaternion _invDefaultRotation = Quaternion.Inverse(_defaultRotation);
 
+    public static Vector3 ToUnityVector(float x, float y, float z)
+    {
+        return new Vector3(
+            x,
+            y,
+            -z
+        );
+    }
 
     public static Vector3 ToUnityVector(List<float> translation)
     {


### PR DESCRIPTION
Add NavmeshHelper class. This class should be provided a navmesh as triangles (UpdateNavmesh). It currently uses the navmesh to restrict VR teleportation, but we don't fully restrict avatar movement. Because of this, user code should still provide a floor collision plane, to prevent the avatar falling through the world when it leaves the navmesh.

I also modify GfxReplayPlayer to look for a navmesh message and pass it to NavmeshHelper. In practice, we get a new navmesh whenever the client joins or whenever the server changes the scene. See also [this hab-lab PR](https://github.com/facebookresearch/habitat-lab/pull/1680).

This code is a bit messy and I documented some cleanup in [this Asana task](https://app.asana.com/0/1205278804336681/1205931235223778).