### PR TITLE
Add skinning replay support.

### DIFF
--- a/Assets/Scripts/GfxReplaySkinnedMesh.cs
+++ b/Assets/Scripts/GfxReplaySkinnedMesh.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GfxReplaySkinnedMesh : MonoBehaviour
+{
+    public int rigId {get; set;} = Constants.ID_UNDEFINED;
+
+    private Transform[] _bones;
+
+    SkinnedMeshRenderer _skinnedMeshRenderer;
+
+    void Awake()
+    {
+        _skinnedMeshRenderer = GetComponentInChildren<SkinnedMeshRenderer>();
+        if (_skinnedMeshRenderer == null)
+        {
+            Debug.LogError($"Object '{name}' has no SkinnedMeshRenderer. Skinning will not be applied.");
+            enabled = false;
+            return;
+        }
+
+        // Hide the skinned mesh until it is configured (i.e. until RigCreation is received).
+        _skinnedMeshRenderer.enabled = false;
+
+        // We don't update bounds every update. Instead, we never cull the skinned mesh.
+        _skinnedMeshRenderer.updateWhenOffscreen = true;
+    }
+
+    public void configureRigInstance(List<string> boneNames)
+    {
+        if (!enabled)
+        {
+            return;
+        }
+        if (_skinnedMeshRenderer.bones.Length != boneNames.Count + 1) // 'boneNames' doesn't include the root.
+        {
+            Debug.LogError($"Skinned object '{name}' does not have the same number of bones than the rig {rigId}.");
+            enabled = false;
+            return;
+        }
+
+        // Match Unity bones to Habitat bone indices using bone names.
+        _bones = new Transform[boneNames.Count];
+        
+        int matchedBoneCount = 0;
+        for (int i = 0; i < boneNames.Count; ++i)
+        {
+            for (int j = 0; j < _skinnedMeshRenderer.bones.Length; ++j)
+            {
+                if (boneNames[i] == _skinnedMeshRenderer.bones[j].gameObject.name)
+                {
+                    _bones[i] = _skinnedMeshRenderer.bones[j];
+                    ++matchedBoneCount;
+                    continue;
+                }
+            }
+        }
+        if (matchedBoneCount != boneNames.Count)
+        {
+            Debug.LogError($"Skinned object '{name}' does not match the bones defined in rig {rigId}.");
+            enabled = false;
+        }
+
+        _skinnedMeshRenderer.enabled = true;
+    }
+
+    public void setPose(List<RigUpdate.BoneTransform> pose) {
+        if (!enabled)
+        {
+            return;
+        }
+        if (_bones == null)
+        {
+            Debug.LogError($"Skinned object '{name}' is not configured.");
+            enabled = false;
+            return;
+        }
+        if (pose == null || pose.Count != _bones.Length)
+        { 
+            Debug.LogError($"Invalid pose submitted to skinned object '{name}'.");
+            enabled = false;
+            return;
+        }
+
+        for (int i = 0; i < pose.Count; ++i)
+        {
+            _bones[i].position = CoordinateConventionHelper.ToUnityVector(pose[i].t);
+            _bones[i].rotation = CoordinateConventionHelper.ToUnityQuaternion(pose[i].r);
+        }
+    }
+}

--- a/Assets/Scripts/GfxReplaySkinnedMesh.cs
+++ b/Assets/Scripts/GfxReplaySkinnedMesh.cs
@@ -84,8 +84,8 @@ public class GfxReplaySkinnedMesh : MonoBehaviour
 
         for (int i = 0; i < pose.Count; ++i)
         {
-            _bones[i].position = CoordinateConventionHelper.ToUnityVector(pose[i].t);
-            _bones[i].rotation = CoordinateConventionHelper.ToUnityQuaternion(pose[i].r);
+            _bones[i].position = CoordinateSystem.ToUnityVector(pose[i].t);
+            _bones[i].rotation = CoordinateSystem.ToUnityQuaternion(pose[i].r);
         }
     }
 }

--- a/Assets/Scripts/GfxReplaySkinnedMesh.cs.meta
+++ b/Assets/Scripts/GfxReplaySkinnedMesh.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6dffea2a83517b8d5bc9741775501b74
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Keyframe.cs
+++ b/Assets/Scripts/Keyframe.cs
@@ -1,6 +1,18 @@
 using System;
 using System.Collections.Generic;
 
+public static class Constants
+{
+    public const int ID_UNDEFINED = -1;
+}
+
+[Serializable]
+public class AbsTransform
+{
+    public List<float> translation;
+    public List<float> rotation;
+}
+
 [Serializable]
 public class KeyframeWrapper
 {
@@ -11,8 +23,10 @@ public class KeyframeWrapper
 public class KeyframeData
 {
     public Load[] loads;
+    public RigCreation[] rigCreations;
     public CreationItem[] creations;
     public StateUpdate[] stateUpdates;
+    public RigUpdate[] rigUpdates;
     public int[] deletions;
     public Message message;
 }
@@ -50,6 +64,7 @@ public class Creation
 {
     public string filepath;
     public float[] scale;
+    public int rigId;
 }
 
 [Serializable]
@@ -71,6 +86,27 @@ public class StateUpdate
             public List<float> rotation;
         }
     }
+}
+
+[Serializable]
+public class RigCreation
+{
+    public int id;
+    public List<string> boneNames;
+}
+
+[Serializable]
+public class RigUpdate
+{
+    [Serializable]
+    public class BoneTransform
+    {
+        public List<float> t;
+        public List<float> r;
+    }
+
+    public int id;
+    public List<BoneTransform> pose;
 }
 
 [Serializable]


### PR DESCRIPTION
This adds support for replaying skinned meshes into Unity.
These values are currently not interpolated. This will be addressed as a polishing task.

https://github.com/eundersander/siro_hitl_unity_client/assets/110583667/696178f9-f390-42e2-8324-b03bb375f6dd

Depends on: https://github.com/facebookresearch/habitat-lab/pull/1791