### PR TITLE
Add query string parsing.

### DIFF
--- a/Assets/Scripts/ClientState.cs
+++ b/Assets/Scripts/ClientState.cs
@@ -8,6 +8,7 @@ public class ClientState
 {
     public AvatarData avatar;
     public ButtonInputData input;
+    public Dictionary<string, string> connection_params_dict;
 }
 
 [Serializable]


### PR DESCRIPTION
This PR adds query string parsing to `NetworkClient`. See server implementation: https://github.com/facebookresearch/habitat-lab/pull/1795.

Behavior:
* The query string is parsed as a dict and sent to the server **in the first message**.
* The parameter `server_hostname` overrides the hostname defined in config.
* The parameter `server_port` overrides the port defined in config.
* The JSON serializer is changed to allow for omission of null parameters.

Example usage:
In browser, launch the client with args: `127.0.0.1:10101/?server_hostname=address&server_port=8888&other_field=data`

Tested that the server correctly receives the query parameters, and that the client can be overridden.